### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://alfonsomarrufo.visualstudio.com/064ddb6e-0a11-4c28-9022-c850908b4de9/48d9daaf-ab7c-4695-989d-1bd059128319/_apis/work/boardbadge/ef3f226c-b804-443e-bc7b-4ad47b85769d)](https://alfonsomarrufo.visualstudio.com/064ddb6e-0a11-4c28-9022-c850908b4de9/_boards/board/t/48d9daaf-ab7c-4695-989d-1bd059128319/Microsoft.RequirementCategory)
 # Alfonso
 Bit coin


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://alfonsomarrufo.visualstudio.com/064ddb6e-0a11-4c28-9022-c850908b4de9/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.